### PR TITLE
add -fでのバグ修正

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ fn main() {
 
             if matches.is_present("force") {
                 match fs::read_dir(&target_project_path) {
-                    Err(err) => panic!("{}", err),
+                    Err(err) => {},
                     Ok(_)    => commands::delete(&target_project_path).unwrap()
                 }
             }


### PR DESCRIPTION
add -fした際に同じ名前のboilerplateがなければバグが起きていた。同じ名前のboilerplateがない場合スルーで対応